### PR TITLE
Added Firebase IP Service tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ For detailed instructions on how to run system please refer to Appendix D of the
 To help with the development of the project, the team has created a few tools that allow for quick tests. The tools are as follows:
 * [Beacon Analyzer](https://github.com/bardia-p/carleton-mail-delivery-robot/tree/master/tools/Beacon_Analyzer): This tool allows the developers to quickly measure the range and signal strength of the beacons and record them in a CSV file.
 * [Wall Follow Simulator](https://github.com/bardia-p/carleton-mail-delivery-robot/tree/master/tools/Wall_Follow_Simulator): This tool allows the developers to test the wall following algorithm of the robot in a Turtle simulator.
+* [Firebase IP Service](https://github.com/bardia-p/carleton-mail-delivery-robot/tree/master/tools/Firebase_IP_Service): This tool allows the Raspberry Pi to send its IP to a Firebase Realtime Database on boot for easy SSH access to the robot without connection to an external monitor.
 
 ## Other Iterations of the Project
 As previously mentioned this is a continuious project. You can find the previous iterations of the project here for reference:

--- a/tools/Firebase_IP_Service/README.md
+++ b/tools/Firebase_IP_Service/README.md
@@ -1,0 +1,49 @@
+# Firebase IP Service
+
+This tool can be used to run a systemd service that posts the IP of a raspberry pi to a Firebase Realtime Database
+
+## Firebase Setup and Script Configuration
+
+The following steps should be followed to create a Firebase database and configure the script.
+
+1. Go to https://console.firebase.google.com/ and login to a Google account (can make a new one or use an existing account)
+2. Click on the “add project” button and give the project a name (ex. create-ip)
+3. Create the project
+4. Add a realtime database and anonymous authentication to the project
+5. Find the API key from the project settings page
+6. Edit the fwdip.py file and add your Firebase information to the CONFIG dictionary. The apiKey value should be your project's API key, the authDomain value should be "<PROJECT_NAME>.firebaseapp.com", the database URL value should be "https://<PROJECT_NAME>-default-rtdb.firebaseio.com/", and storageBucket should be "<PROJECT_NAME>.appspot.com". Replace <PROJECT_NAME> values with the project name chosen in step 2 (ex. "authDomain: "create3-ip.firebaseapp.com").
+7. Configure the "CHILD" value with the name you want sent to the firebase. When using mutliple create 3 robots, change this value so that you know the associated IP of each robot.
+
+## Installing Pyrebase
+
+In order to post the IP of the pi to the firebase database, the Pyrebase Python library must be installed.
+
+You can install Pyrebase by running the following command:
+
+```
+pip3 install Pyrebase4
+```
+
+#####  Note: Pyrebase4 is recomended as it solves issues with the requests library in Python 3.10
+
+## Running the service
+
+Before setting up the service to run, modify the ExecStart path in the fwdip.service file. The ExecStart path should point to the fwdip_helper.sh script which must be in the same folder as the fwdip.py script. You may also edit the log file paths as desired.
+
+Now to have the service run on system boot, copy the fwdip.service file to the /etc/systemd/system folder and start it by running the following commands.
+
+```
+cp fwdip.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl start fwdip.service
+```
+
+The status of the service can then be check as follows:
+
+```
+sudo systemctl status fwdip.service
+```
+
+## Using the service
+
+With the above configuration completed, the Raspberry Pi will post its IP address to your Firebase Realtime Database every time it boots. To access the IP, navigate to your Firebase project page and click on the "realtime database" button.

--- a/tools/Firebase_IP_Service/fwdip.py
+++ b/tools/Firebase_IP_Service/fwdip.py
@@ -1,0 +1,33 @@
+# This Python script requires a network connection and ssl certs before running.
+# To check this automatically, use the fwdip_helper.sh script to run.
+
+from pyrebase.pyrebase import Database
+from pyrebase import initialize_app as initApp
+import urllib.request as ur
+from subprocess import check_output
+from time import sleep
+import os
+
+# Fill out the config with the information from your Firebase Real time database
+CONFIG = {
+        "apiKey": "AIzaSyAWtAoHIuIGsiMT035-A6SyvvbeDhv6b0o",
+        "authDomain": "create3-ip.firebaseapp.com",
+        "databaseURL": "https://create3-ip-default-rtdb.firebaseio.com/",
+        "storageBucket": "create3-ip.appspot.com"
+}
+
+# Set the CHILD to whatever you want to name the ip address entry
+CHILD: str = "CREATE3-1"
+
+def ip_post():
+
+    ip_address = os.popen("ip route get 8.8.8.8 | awk '{gsub(\".*src\", \"\"); print $1; exit}'").read()
+    print("IP address:", ip_address)
+
+    firebase = initApp(CONFIG)
+    db: Database = firebase.database()
+    db.child(CHILD).set(ip_address)
+
+
+if __name__ == "__main__":
+	ip_post()

--- a/tools/Firebase_IP_Service/fwdip.service
+++ b/tools/Firebase_IP_Service/fwdip.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Firebase IP Service
+After=network.target
+
+[Service]
+User=ubuntu
+Type=oneshot
+ReaminAfterExit=true
+ExecStart=/bin/fwdip/fwdip_helper.sh
+StandardOutput=append:/home/ubuntu/fwdip.log
+StandardError=append:/home/ubuntu/fwdip.log
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/Firebase_IP_Service/fwdip_helper.sh
+++ b/tools/Firebase_IP_Service/fwdip_helper.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Shell script to make sure SSL and Network are ready before running fwdip.py
+
+# Function to check if SSL certificates are set up
+check_ssl_certificates() {
+    # Check if SSL certificates directory exists and is not empty
+    if [ -d "/etc/ssl/certs" ] && [ "$(ls -A /etc/ssl/certs)" ]; then
+        return 0  # SSL certificates are set up
+    else
+        return 1  # SSL certificates are not set up
+    fi
+}
+
+# Wait for network connectivity
+while ! ping -c 1 google.com >/dev/null 2>&1; do
+    sleep 1
+done
+
+# Wait for SSL certificates to be set up
+while ! check_ssl_certificates; do
+    sleep 1
+done
+
+/usr/bin/python3 ./fwdip.py


### PR DESCRIPTION
Added the Firebase IP Service tool to the project tool folder. The fwdip.service file contains the systemd configuration to run the fwdip_helper.sh script on boot of the Raspberry Pi. The fwdip_helper.sh script will wait until a network connection is up and the ssl certificates are established before running fwdip.py. The fwdip.py Python script sends the current IP address to the Firebase realtime database.

A README was added to explain the setup process and the main README was edited to add a link to the new tool.